### PR TITLE
[IIIF-542] Fix S3 resource deprecated region field

### DIFF
--- a/.travis/terraform-validate.sh
+++ b/.travis/terraform-validate.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Module terraform validate script
 
-TERRAFORM_VERSION="0.12.5"
+TERRAFORM_VERSION="0.12.9"
 TERRAFORM_URL="https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
 TERRAFORM_BIN="${HOME}/terraform/bin"
 TERRAFORM="${TERRAFORM_BIN}/terraform"

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,11 @@
+provider "aws" {
+  alias  = "bucket_region"
+  region = "${var.bucket_region}"
+}
+  
 resource "aws_s3_bucket" "bucket" {
   bucket        = "${var.bucket_name}"
-  region        = "${var.bucket_region}"
+  provider      = aws.bucket_region
   force_destroy = "${var.force_destroy_flag}"
   acl           = "private"
 }


### PR DESCRIPTION
The latest AWS provider libraries(3.x.x) removed the region field from the s3 bucket resource. The preferred method is to inherit the provider region or defined multiple provider aliases and pass that through.

This is currently breaking our Travis builds when running `terraform validate`